### PR TITLE
Update wetterdienst, add Docker and loading gif

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,6 @@
 [flake8]
 select = B,B9,BLK,C,E,F,W,S
-ignore = E203,W503
+ignore = E203,W503,S104
 max-line-length = 88
 per-file-ignores =
     tests/*:S101

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,8 +5,15 @@ Changelog
 Development
 ===========
 
-0.1.0 (12.02.2021)
+0.0.1 (12.02.2021)
 ==================
 
 - initial release
 - update README.rst
+
+0.0.2 (03.03.2021)
+==================
+
+- Added a loader icon while data will be downloaded
+- Docker support
+- now on wetterdienst 0.14.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM python:3.9.1-slim
+
+RUN set -ex \
+    && apt update \
+    && apt install -y apt-transport-https curl
+
+COPY ./requirements.txt /opt/requirements.txt
+RUN pip install -r /opt/requirements.txt
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y locales libcairo2
+RUN update-ca-certificates --fresh
+
+RUN sed -i -e 's/# de_DE.UTF-8 UTF-8/de_DE.UTF-8 UTF-8/' /etc/locale.gen && \
+    dpkg-reconfigure --frontend=noninteractive locales && \
+    update-locale LANG=de_DE.UTF-8
+ENV LC_ALL 'de_DE.UTF-8'
+ENV LC_CTYPE 'de_DE.UTF-8'
+
+ENV PYTHONPATH "/app:/app"
+ENV PORT 8050
+
+WORKDIR /app
+CMD gunicorn -b 0.0.0.0:$PORT --workers 4 ui.app:server

--- a/README.rst
+++ b/README.rst
@@ -26,15 +26,37 @@ Run the wetterdienst user interface from the project directory by these commands
 * CLI: `python3 ui/app.py`
 
 Access via: http://127.0.0.1:8050/
-Don't forget to set the `PYTHONPATH`
+Don't forget to set the `PYTHONPATH` and install all dependencies.
+
+Using Docker
+____________
+
+First you have to build the image by calling:
+
+.. code-block:: bash
+
+    docker build -t "wetterdienst_ui" .
+
+And then run the app:
+
+.. code-block:: bash
+
+    docker run -ti --rm -p 8050:8050 -v $(pwd):/app wetterdienst_ui:latest
+
+
+Please note the import `-p` tag which enables the port forwarding.
 
 Issues
 ========
-* Add a loader icon while data will be downloaded
-* Support run in Docker
 * Implement different figure types for different data types
 * Provide more information for weather station (location, avail.) on the front-end
 * Display extremes of actual visualisation
 * Support overlays
 * Zoom map to selected station
 * enable select station by click on an icon on map (requires ipyleaflet)
+
+Known Bugs
+==========
+
+* `_gdbm.error: [Errno 11] Resource temporarily unavailable: '/root/.cache/wetterdienst/metaindex.dbm'`
+    Sometimes there are problems with a wetterdienst cache. You can work around this bug by switching between sudo and not sudo call

--- a/noxfile.py
+++ b/noxfile.py
@@ -59,14 +59,14 @@ def coverage(session: Session) -> None:
 locations = "ui", "tests", "noxfile.py"
 
 
-@nox.session(python=["3.6", "3.7", "3.8"])
+@nox.session(python=["3.6", "3.7", "3.8", "3.9"])
 def black(session):
     args = session.posargs or locations
     session.install("black")
     session.run("black", *args)
 
 
-@nox.session(python=["3.6", "3.7", "3.8"])
+@nox.session(python=["3.6", "3.7", "3.8", "3.9"])
 def lint(session):
     args = session.posargs or locations
     session.install("flake8", "flake8-bandit", "flake8-black", "flake8-bugbear")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+pandas==1.2.2
+tables==3.6.1
+numpy==1.20.1
+scipy==1.6.1
+plotly==4.14.0
+dash==1.19.0
+gunicorn==20.0.4
+dash-bootstrap-components==0.10.8rc1
+wetterdienst==0.14.1

--- a/ui/layouts/observations_germany.py
+++ b/ui/layouts/observations_germany.py
@@ -1,7 +1,6 @@
 """ holds html layout for observation dashboard """
-import dash_html_components as html
 import dash_core_components as dcc
-
+import dash_html_components as html
 from wetterdienst.dwd.observations import (
     DWDObservationPeriod,
     DWDObservationResolution,
@@ -57,11 +56,19 @@ def dashboard_layout() -> html:
                                 multi=False,
                                 className="dcc_control",
                             ),
-                            html.P("Select variable when data was downloaded:"),
-                            dcc.Dropdown(
-                                id="select-variable",
-                                multi=False,
-                                className="dcc_control",
+                            html.P("Select variable:"),
+                            dcc.Loading(
+                                id="loading-1",
+                                children=[
+                                    dcc.Dropdown(
+                                        id="select-variable",
+                                        multi=False,
+                                        className="dcc_control",
+                                    ),
+                                    html.Div(
+                                        [], id="hidden-div", style={"display": "None"}
+                                    ),
+                                ],
                             ),
                         ],
                         className="pretty_container four columns",
@@ -89,7 +96,6 @@ def dashboard_layout() -> html:
                 ],
                 className="row flex-display",
             ),
-            html.Div([], id="hidden-div", style={"display": "None"}),
             html.Div([], id="hidden-div-metadata", style={"display": "None"}),
         ],
         id="mainContainer",


### PR DESCRIPTION
Added Docker support, use latest wetterdienst version and added loading gif (dcc.loading).

I run into trouble with wetterdienst caches stored under root directory. The work around is to run docker with sudo. 

